### PR TITLE
fix: Use slashes in folder names instead of division slashes added by Gazer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@looker-open-source/cloud-looker-devrel

--- a/looker_deployer/commands/deploy_content.py
+++ b/looker_deployer/commands/deploy_content.py
@@ -52,7 +52,7 @@ def create_or_return_space(space_name, parent_id, sdk):
         target_id = get_space_ids_from_name(space_name, parent_id, sdk)
         if len(target_id) == 0 and "/" in space_name:
             # If the folder name contains slashes then also check if it was previously imported with
-            # the slashes replaced with division slashes (Unicode character 2215) prior to PR #152.
+            # the slashes replaced with division slashes (Unicode character 2215) prior to PR #153.
             target_id = get_space_ids_from_name(space_name.replace("/", "\u2215"), parent_id, sdk)
         logger.debug("Space ID from name", extra={"id": target_id})
         assert len(target_id) == 1


### PR DESCRIPTION
When Gazer exports folders it replaces slashes with division slashes (Unicode character 2215) in the corresponding local folder name, and when Looker Deployer is importing content it's using the local folder names to create folders in the target Looker instance, which results in folders whose names contain slashes getting slightly mangled to contain division slashes when they're imported. This PR attempts to restore the original folder names containing normal slashes when importing.

Copy of https://github.com/looker-open-source/looker_deployer/pull/152 running from a local branch so tests run properly.